### PR TITLE
refactor: header layout

### DIFF
--- a/src/public/js/common.js
+++ b/src/public/js/common.js
@@ -1,10 +1,14 @@
 'use strict';
 
-// header mobile navigation
-const navBtn = document.getElementById('navBtn');
-navBtn.addEventListener('click', () => {
+/*
+---------------------------------------
+| Toggle header mobile navigation
+---------------------------------------
+*/
+const mobileNavTrigger = document.getElementById('mobileNavTrigger');
+mobileNavTrigger.addEventListener('click', () => {
     document.getElementById('mobileNav').classList.toggle('collapse');
-    navBtn.classList.toggle('close');
+    mobileNavTrigger.classList.toggle('close');
 });
 
 /*

--- a/src/resources/sass/front/_header.scss
+++ b/src/resources/sass/front/_header.scss
@@ -65,7 +65,7 @@
 
 /* Mobile Navigation Button
 -------------------------*/
-.navbtn {
+.mobile-nav-btn {
   -webkit-mask-image: url(../../../public/images/icon-mobile-menu-open.svg);
   -webkit-mask-repeat: no-repeat;
   -webkit-mask-position: center;

--- a/src/resources/sass/front/_header.scss
+++ b/src/resources/sass/front/_header.scss
@@ -8,7 +8,10 @@
 }
 
 .header-container {
+  align-items: center;
   color: var(--white);
+  display: flex;
+  justify-content: space-between;
   padding: 16px 4%;
 
   @include pc-screen() {
@@ -16,12 +19,6 @@
     max-width: var(--max-width-pc);
     padding: 16px 24px;
   }
-}
-
-.header-block {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
 }
 
 /* Site Title

--- a/src/resources/sass/front/_header.scss
+++ b/src/resources/sass/front/_header.scss
@@ -2,6 +2,7 @@
 
 .layout-header {
   background-color: var(--navy);
+  height: var(--header-height);
   position: sticky;
   top: 0;
   z-index: 100;
@@ -11,6 +12,7 @@
   align-items: center;
   color: var(--white);
   display: flex;
+  height: 100%;
   justify-content: space-between;
   padding: 16px 4%;
 

--- a/src/resources/sass/front/_header.scss
+++ b/src/resources/sass/front/_header.scss
@@ -3,8 +3,9 @@
 .layout-header {
   background-color: var(--navy);
   height: var(--header-height);
-  position: sticky;
+  position: fixed;
   top: 0;
+  width: 100%;
   z-index: 100;
 }
 

--- a/src/resources/sass/front/_main.scss
+++ b/src/resources/sass/front/_main.scss
@@ -2,6 +2,7 @@
 
 .layout-main {
   background-color: var(--body-color);
+  padding-top: var(--header-height);
 }
 
 .main-container {

--- a/src/resources/sass/global/_variables.scss
+++ b/src/resources/sass/global/_variables.scss
@@ -3,6 +3,7 @@
   /* Height
   -------------------------*/
   --header-height: 64px;
+  scroll-padding-top: calc(var(--header-height) + 32px);
 
   /* Width
   -------------------------*/

--- a/src/resources/sass/global/_variables.scss
+++ b/src/resources/sass/global/_variables.scss
@@ -1,4 +1,9 @@
 :root {
+
+  /* Height
+  -------------------------*/
+  --header-height: 64px;
+
   /* Width
   -------------------------*/
   --max-width-pc: 1040px;

--- a/src/resources/views/front/_layout/header.blade.php
+++ b/src/resources/views/front/_layout/header.blade.php
@@ -1,34 +1,34 @@
 <header class="layout-header">
     <div class="header-container">
-            {{-- Site Title --}}
-            <div class="site-title-box">
-                <a href="{{ route('home') }}" class="site-title">
-                    <div class="main-title">Rz Note</div>
-                    <div class="sub-title">with <span>Laravel</span></div>
-                </a>
+        {{-- Site Title --}}
+        <div class="site-title-box">
+            <a href="{{ route('home') }}" class="site-title">
+                <div class="main-title">Rz Note</div>
+                <div class="sub-title">with <span>Laravel</span></div>
+            </a>
+        </div>
+
+        {{-- Search Form --}}
+        <div id="searchModalTrigger" class="search-box">
+            <span class="material-symbols-outlined">
+                search
+            </span>
+            <div class="placeholder">
+                Search
             </div>
+        </div>
 
-            {{-- Search Form --}}
-            <div id="searchModalTrigger" class="search-box">
-                <span class="material-symbols-outlined">
-                    search
-                </span>
-                <div class="placeholder">
-                    Search
-                </div>
-            </div>
+        {{-- Mobile Navigation Button --}}
+        <div id="navBtn" class="navbtn"></div>
 
-            {{-- Mobile Navigation Button --}}
-            <div id="navBtn" class="navbtn"></div>
-
-            {{-- PC Navigation --}}
-            <nav class="pc-nav">
-                <ul class="nav-list">
-                    <li class="nav-item"><a href="{{ route('home') }}" class="nav-link">HOME</a></li>
-                    <li class="nav-item"><a href="#" class="nav-link">Profile</a></li>
-                    <li class="nav-item"><a href="#" class="nav-link">Contact</a></li>
-                </ul>
-            </nav>
+        {{-- PC Navigation --}}
+        <nav class="pc-nav">
+            <ul class="nav-list">
+                <li class="nav-item"><a href="{{ route('home') }}" class="nav-link">HOME</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">Profile</a></li>
+                <li class="nav-item"><a href="#" class="nav-link">Contact</a></li>
+            </ul>
+        </nav>
     </div>
 
     {{-- Mobile Navigation --}}

--- a/src/resources/views/front/_layout/header.blade.php
+++ b/src/resources/views/front/_layout/header.blade.php
@@ -19,7 +19,7 @@
         </div>
 
         {{-- Mobile Navigation Button --}}
-        <div id="navBtn" class="navbtn"></div>
+        <div id="mobileNavTrigger" class="mobile-nav-btn"></div>
 
         {{-- PC Navigation --}}
         <nav class="pc-nav">

--- a/src/resources/views/front/_layout/header.blade.php
+++ b/src/resources/views/front/_layout/header.blade.php
@@ -1,6 +1,5 @@
 <header class="layout-header">
     <div class="header-container">
-        <div class="header-block">
             {{-- Site Title --}}
             <div class="site-title-box">
                 <a href="{{ route('home') }}" class="site-title">
@@ -30,7 +29,6 @@
                     <li class="nav-item"><a href="#" class="nav-link">Contact</a></li>
                 </ul>
             </nav>
-        </div>
     </div>
 
     {{-- Mobile Navigation --}}

--- a/src/resources/views/front/_layout/header.blade.php
+++ b/src/resources/views/front/_layout/header.blade.php
@@ -30,13 +30,13 @@
             </ul>
         </nav>
     </div>
-
-    {{-- Mobile Navigation --}}
-    <nav id="mobileNav" class="mobile-nav collapse">
-        <ul class="nav-list">
-            <li class="nav-item"><a href="{{ route('home') }}" class="nav-link">HOME</a></li>
-            <li class="nav-item"><a href="#" class="nav-link">Profile</a></li>
-            <li class="nav-item"><a href="#" class="nav-link">Contact</a></li>
-        </ul>
-    </nav>
 </header>
+
+{{-- Mobile Navigation --}}
+<nav id="mobileNav" class="mobile-nav collapse">
+    <ul class="nav-list">
+        <li class="nav-item"><a href="{{ route('home') }}" class="nav-link">HOME</a></li>
+        <li class="nav-item"><a href="#" class="nav-link">Profile</a></li>
+        <li class="nav-item"><a href="#" class="nav-link">Contact</a></li>
+    </ul>
+</nav>


### PR DESCRIPTION
- 不要な要素の削除、クラス名の変更等
- headerの高さを64pxで固定
- スマホ画面時の開閉ナビをheaderの外側に配置（開いた時に元の要素がheaderの下に隠れることを防ぐ）
- アンカーリンクでスクロールした時にheaderの高さ分ずれるため`scroll-padding-top`で解消
- header固定方法を`position` : `sticky`から`fixed`に変更。（stickyだとスクロール時にブラウザがずれて外側？余白？のような部分が見えるような動きをするため）